### PR TITLE
Support for nested handlers in routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,31 @@ admin.route({
 });
 ```
 
+## Nested middleware support
+
+You may want to bundle and nest middleware in different ways for reuse and
+organization purposes.
+
+```js
+var router = require('koa-joi-router');
+var admin = router();
+var commonMiddleware = [ yourMiddleware, someOtherMiddleware ];
+admin.route({
+  path: '/',
+  method: ['POST', 'PUT'],
+  handler: [ commonMiddleware, yourHandler ]
+});
+```
+
+This also works with the .get(),post(),put(),del(), etc HTTP method helpers.
+
+```js
+var router = require('koa-joi-router');
+var admin = router();
+var commonMiddleware = [ yourMiddleware, someOtherMiddleware ];
+admin.get('/', commonMiddleware, yourHandler);
+```
+
 ## Handling errors
 
 By default, `koa-joi-router` stops processing the middleware stack when either

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -1,0 +1,24 @@
+'use strict';
+
+exports.MiddlewareGenerator = MiddlewareGenerator;
+
+function MiddlewareGenerator() {
+  this.count = 0;
+}
+
+MiddlewareGenerator.prototype.generate = function() {
+  var i = this.count += 1;
+  var self = this;
+  return function*(next) {
+    var expectedBody = (i - 1) + ' out of ' + self.count;
+    if (i > 1 && this.body !== expectedBody) {
+      this.throw(400, 'Handler executed out-of-order');
+    }
+    this.body = i + ' out of ' + self.count;
+    yield next;
+  };
+};
+
+MiddlewareGenerator.prototype.getExpectedBody = function() {
+  return this.count + ' out of ' + this.count;
+};


### PR DESCRIPTION
This change supports nested groupings of handler middleware when defining routes.

For example, it is possible that many routes may share a common set of middleware from separate sources.  Being able to group this middleware would simplify route definitions and could allow the middleware-related dependencies to be declared separately from the routes:

```js
// middleware.js
const auth = require('auth-middleware');
const logger = require('log-middleware');
const session = require('session-middleware');
const other = require('other-middleware');

exports.logger = logger();
exports.protectedSession = [
  auth(),
  session(),
  other()
];
```

```js
// app.js
const koa = require('koa');
const joiRouter = require('koa-joi-router');
const middleware = require('./middleware');

var app = koa();
var router = joiRouter();

// Common logging middleware
app.use(middleware.logger);

router.route([
  {
    path: '/info',
    method: 'GET',
    handler: function*() {
      // ...
    }
  },
  {
    path: '/item',
    method: 'POST',
    handler: [middleware.protectedSession, function*() {
      // ...
    }]
  },
  {
    path: '/item/:itemId',
    method: 'UPDATE',
    handler: [middleware.protectedSession, function*() {
      // ...
    }]
  }
]);
```

Unit tests are also improved with more `supertest`-backed coverage.

- [x] Unit tests
- [x] Coverage
- [x] Documentation