### PR TITLE
Updated npm packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,14 @@
   "homepage": "https://github.com/koajs/joi-router",
   "dependencies": {
     "clone": "1.0.2",
-    "co-body": "4.0.0",
-    "co-busboy": "1.3.0",
+    "co-body": "4.2.0",
+    "co-busboy": "1.3.1",
     "debug": "2.2.0",
     "delegates": "0.1.0",
     "flatten": "0.0.1",
     "is-gen-fn": "0.0.1",
-    "joi": "6.6.1",
-    "koa-router": "5.2.3",
+    "joi": "8.4.2",
+    "koa-router": "5.4.0",
     "methods": "1.1.1",
     "sliced": "1.0.1"
   },


### PR DESCRIPTION
This library is using an outdated version of `joi`, there are a handful of useful new APIs available in version [8.x](https://github.com/hapijs/joi/blob/v8/API.md).
Also updated `co-body`, `co-bus-boy`, and `koa-router` to latest version.