### PR TITLE
Fixed basic example

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,9 +88,9 @@ public.route({
   }
 });
 
-const app = koa();
+const app = new koa();
 app.use(public.middleware());
-app.listen();
+app.listen(3000);
 ```
 
 ## Usage


### PR DESCRIPTION
To avoid this:
```bash
const app = koa();
            ^
TypeError: Class constructor Application cannot be invoked without 'new'
```