### PR TITLE
Exposed param to allow for parameter checking on the route level

### DIFF
--- a/joi-router.js
+++ b/joi-router.js
@@ -41,7 +41,8 @@ function Router() {
 
 delegate(Router.prototype, 'router')
   .method('prefix')
-  .method('use');
+  .method('use')
+  .method('param');
 
 /**
  * Return koa middleware


### PR DESCRIPTION
Adding this param so that you can do a check on the param at the router level rather than putting it into the routes list.