### PR TITLE
Update debug dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "await-busboy": "1.0.1",
     "clone": "2.1.1",
     "co-body": "5.0.2",
-    "debug": "2.6.1",
+    "debug": "^2.6.9",
     "delegates": "1.0.0",
     "flatten": "1.0.2",
     "is-gen-fn": "0.0.1",
@@ -61,7 +61,7 @@
       "pebble"
     ],
     "parserOptions": {
-        "ecmaVersion": 2017
+      "ecmaVersion": 2017
     }
   }
 }


### PR DESCRIPTION
Update the debug package to >=2.6.9 to fix a DoS vulnerability, see:
https://nodesecurity.io/advisories/534

`npm test` passes.

I took the liberty of adding the `^` operator to make things like this easier going forward; feel free to remove it if you prefer to keep the dependency version pinned.