### PR TITLE
Support pre handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ public.route({
     failure: 400,
     continueOnError: false
   },
+  pre: async (ctx, next) => {
+    await checkAuth(ctx);
+    return next();
+  },
   handler: async (ctx) => {
     await createUser(ctx.request.body);
     ctx.status = 201;
@@ -202,6 +206,7 @@ public.route(routes);
   - `output`: see [output validation](#validating-output)
   - `continueOnError`: if validation fails, this flags determines if `koa-joi-router` should [continue processing](#handling-errors) the middleware stack or stop and respond with an error immediately. useful when you want your route to handle the error response. default `false`
 - `handler`: **required** async function or function
+- `pre`: async function or function, will be called before parser and validators
 - `meta`: meta data about this route. `koa-joi-router` ignores this but stores it along with all other route data
 
 ### .get(),post(),put(),delete() etc - HTTP methods

--- a/joi-router.js
+++ b/joi-router.js
@@ -117,15 +117,17 @@ Router.prototype._addRoute = function addRoute(spec) {
   const bodyParser = makeBodyParser(spec);
   const specExposer = makeSpecExposer(spec);
   const validator = makeValidator(spec);
+  const preHandlers = spec.pre ? flatten(spec.pre) : [];
   const handlers = flatten(spec.handler);
 
   const args = [
-    spec.path,
+    spec.path
+  ].concat(preHandlers, [
     prepareRequest,
     specExposer,
     bodyParser,
     validator
-  ].concat(handlers);
+  ], handlers);
 
   const router = this.router;
 
@@ -148,6 +150,7 @@ Router.prototype._validateRouteSpec = function validateRouteSpec(spec) {
   assert(ok, 'invalid route path');
 
   checkHandler(spec);
+  checkPreHandler(spec);
   checkMethods(spec);
   checkValidators(spec);
 };
@@ -162,6 +165,22 @@ function checkHandler(spec) {
   }
 
   return flatten(spec.handler).forEach(isSupportedFunction);
+}
+
+/**
+ * @api private
+ */
+
+function checkPreHandler(spec) {
+  if (!spec.pre) {
+    return
+  }
+
+  if (!Array.isArray(spec.pre)) {
+    spec.pre = [spec.pre];
+  }
+
+  return flatten(spec.pre).forEach(isSupportedFunction);
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -165,6 +165,38 @@ describe('koa-joi-router', () => {
         });
       });
 
+      describe('pre', () => {
+        it('should run before validators and handler', (done) => {
+          const r = router();
+
+          r.route({
+            method: 'post',
+            path: '/',
+            validate: {
+              type: 'json',
+              body: {
+                v: Joi.number()
+              }
+            },
+            pre: (ctx, next) => {
+              if (ctx.request.body) {
+                ctx.throw(500, 'pre called after parser');
+              }
+              return next();
+            },
+            handler: (ctx) => {
+              console.log('ctx.request.body', ctx.request.body);
+              ctx.body = ctx.request.body;
+            }
+          });
+
+          return test(makeRouterApp(r))
+            .post('/')
+            .send({v: '42'})
+            .expect({ v: 42 }, done);
+        });
+      });
+
       describe('handler', () => {
         function testHandler(handler, expectedBody, done) {
           const r = router();


### PR DESCRIPTION
Sometimes, before body parsing and validation you need to check preconditions (e.g. jwt authentication).