### PR TITLE
Fill ctx.invalid before throwing error

### DIFF
--- a/joi-router.js
+++ b/joi-router.js
@@ -289,8 +289,8 @@ function makeBodyParser(spec) {
           break;
       }
     } catch (err) {
-      if (!spec.validate.continueOnError) return ctx.throw(err);
       captureError(ctx, 'type', err);
+      if (!spec.validate.continueOnError) return ctx.throw(err);
     }
 
     await next();
@@ -331,8 +331,8 @@ function makeValidator(spec) {
         err = validateInput(prop, ctx, spec.validate);
 
         if (err) {
-          if (!spec.validate.continueOnError) return ctx.throw(err);
           captureError(ctx, prop, err);
+          if (!spec.validate.continueOnError) return ctx.throw(err);
         }
       }
     }


### PR DESCRIPTION
This way I can make an error middleware that can handle validation errors and show a custom response.