### PR TITLE
Router option to pass options to validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ public.route(routes);
      - `autoFields`: Determines whether form fields should be auto-parsed (default: `true`). See the [await-busboy docs](https://github.com/aheckmann/await-busboy#parts--parsestream-options).
   - `output`: see [output validation](#validating-output)
   - `continueOnError`: if validation fails, this flags determines if `koa-joi-router` should [continue processing](#handling-errors) the middleware stack or stop and respond with an error immediately. useful when you want your route to handle the error response. default `false`
+  - `validateOptions`: validator options
 - `handler`: **required** async function or function
 - `pre`: async function or function, will be called before parser and validators
 - `meta`: meta data about this route. `koa-joi-router` ignores this but stores it along with all other route data

--- a/joi-router.js
+++ b/joi-router.js
@@ -474,7 +474,7 @@ function validateInput(prop, ctx, validate) {
   debug('validating %s', prop);
 
   const request = ctx.request;
-  const res = Joi.validate(request[prop], validate[prop]);
+  const res = Joi.validate(request[prop], validate[prop], (validate.validateOptions || {}));
 
   if (res.error) {
     res.error.status = validate.failure;


### PR DESCRIPTION
Can't figure if it's a breaking change in regard of all Joi validation options. Got it working well with `{ abortEarly: false }`.

As it's a per route configuration, it's kinda fix #41.