### PR TITLE
Remove is-gen-fn dependency

### DIFF
--- a/joi-router.js
+++ b/joi-router.js
@@ -2,7 +2,6 @@
 
 const assert = require('assert');
 const debug = require('debug')('koa-joi-router');
-const isGenFn = require('is-gen-fn');
 const flatten = require('flatten');
 const methods = require('methods');
 const KoaRouter = require('@koa/router');
@@ -189,8 +188,7 @@ function checkPreHandler(spec) {
 
 function isSupportedFunction(handler) {
   assert.equal('function', typeof handler, 'route handler must be a function');
-
-  if (isGenFn(handler)) {
+  if (handler && handler.constructor && handler.constructor.name === 'GeneratorFunction') {
     throw new Error(`route handlers must not be GeneratorFunctions
        Please use "async function" or "function".`);
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1590,11 +1590,6 @@
       "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
       "dev": true
     },
-    "is-gen-fn": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/is-gen-fn/-/is-gen-fn-0.0.1.tgz",
-      "integrity": "sha1-8na/KgCDVxq9Aa3UfNTaEFpkzhM="
-    },
     "is-generator-function": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.0.8.tgz",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "debug": "4.1.1",
     "delegates": "1.0.0",
     "flatten": "1.0.3",
-    "is-gen-fn": "0.0.1",
     "joi": "^17.2.1",
     "methods": "1.1.2",
     "sliced": "1.0.1"

--- a/test/index.js
+++ b/test/index.js
@@ -258,6 +258,16 @@ describe('koa-joi-router', () => {
             middleware.generate()
           ], middleware.getExpectedBody(), done);
         });
+
+        it('must not be a generator function', () => {
+          assert.throws(() => {
+            router().route({
+              method: 'get',
+              path: '/',
+              handler: function* generator() {},
+              });
+          }, /handlers must not be GeneratorFunctions/);
+        });
       });
     });
 


### PR DESCRIPTION
The is-gen-fn package causes a DeprecationWarning with Node 16:

     Uncaught DeprecationWarning: Invalid 'main' field in '/home/crowley/work/uniq/uniq-conferencier/node_modules/is-gen-fn/package.json' of 'yes'. Please either fix that or report it to the module author
      at tryPackage (node:internal/modules/cjs/loader:359:15)
      […]

Since it is fairly trivial, just include the generator function check here.