### PR TITLE
update is-gen-fn to 0.0.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "debug": "4.1.1",
     "delegates": "1.0.0",
     "flatten": "1.0.3",
-    "is-gen-fn": "0.0.1",
+    "is-gen-fn": "0.0.2",
     "joi": "^17.2.1",
     "methods": "1.1.2",
     "sliced": "1.0.1"


### PR DESCRIPTION
The following error was found during use.

(node:8628) [DEP0128] DeprecationWarning: Invalid 'main' field in 'F:\starter-koa\node_modules\koa-joi-router\node_modules\is-gen-fn\package.json' of 'yes'. Please either fix th-gen-fn\package.json' of 'yes'. Please either fix that or report it to the module author.

Fixed when viewing is-gen-fn. version 0.0.2.
