### PR TITLE
Apply defaults for empty query validation (#62)

### DIFF
--- a/joi-router.js
+++ b/joi-router.js
@@ -474,7 +474,8 @@ function validateInput(prop, ctx, validate) {
   debug('validating %s', prop);
 
   const request = ctx.request;
-  const res = Joi.compile(validate[prop]).validate(request[prop], validate.validateOptions || {});
+  const requestData = prop === 'query' ? (request[prop] || {}) : request[prop];
+  const res = Joi.compile(validate[prop]).validate(requestData, validate.validateOptions || {});
 
   if (res.error) {
     res.error.status = validate.failure;

--- a/joi-router.js
+++ b/joi-router.js
@@ -474,6 +474,7 @@ function validateInput(prop, ctx, validate) {
   debug('validating %s', prop);
 
   const request = ctx.request;
+  // An absent query string still validates as an empty object so Joi object defaults can apply.
   const requestData = prop === 'query' ? (request[prop] || {}) : request[prop];
   const res = Joi.compile(validate[prop]).validate(requestData, validate.validateOptions || {});
 

--- a/test/index.js
+++ b/test/index.js
@@ -907,6 +907,35 @@ describe('koa-joi-router', () => {
           done(err);
         });
       });
+
+      it('applies query defaults when the querystring is empty (gh-62)', (done) => {
+        const r = router();
+
+        r.route({
+          method: 'get',
+          path: '/a',
+          validate: {
+            query: Joi.object().keys({
+              search: Joi.string(),
+              sort: Joi.object().default({ name: 1 })
+            })
+          },
+          handler: (ctx) => {
+            ctx.body = ctx.request.query;
+          }
+        });
+
+        const app = new Koa();
+        app.use(r.middleware());
+
+        test(app).get('/a')
+        .expect(200)
+        .end((err, res) => {
+          if (err) return done(err);
+          assert.deepEqual({ name: 1 }, res.body.sort);
+          done();
+        });
+      });
     });
 
     describe('of params', () => {


### PR DESCRIPTION
Fixes `koajs/joi-router#62` by validating query input with an empty object when request query is absent, so object-level defaults (for example `Joi.object().default(...)`) apply when the URL has no query string.

## Summary by Sourcery

Validate query parameters against an empty object when no query string is present so that Joi object-level defaults are applied.

Bug Fixes:
- Ensure Joi query schema defaults are applied when the request has no query string by validating against an empty object instead of undefined.

Tests:
- Add a test verifying that query-level default values are populated when the URL query string is empty.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Default query parameter values are now applied when a request has an empty query string; route query defaults are honored consistently.

* **Tests**
  * Added a validation test to ensure query defaults are applied when no query params are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->