### PR TITLE
Expose Joi validation as middleware (#56)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Easy, rich and fully validated [koa][] routing.
 #### Features:
 
 - built in input validation using [joi][]
+- exposed validation middleware factory
 - built in [output validation](#validating-output) using [joi][]
 - built in body parsing using [co-body][] and [await-busboy][]
 - built on the great [@koa/router][]
@@ -130,6 +131,39 @@ release of Joi into the router.
 const koa = require('koa');
 const router = require('koa-joi-router');
 const Joi = router.Joi;
+```
+
+### .validate(config)
+
+Returns standalone Koa middleware for the same validation configuration used by
+route definitions. This allows validation to be composed directly with other
+route middleware.
+
+```js
+const router = require('koa-joi-router');
+const Joi = router.Joi;
+
+const pub = router();
+
+pub.get('/search',
+  router.validate({
+    query: Joi.object().keys({
+      q: Joi.string().required()
+    })
+  }),
+  async (ctx) => {
+    ctx.body = ctx.request.query;
+  });
+```
+
+The factory also accepts the route config shape:
+
+```js
+router.validate({
+  validate: {
+    query: Joi.object().keys({ q: Joi.string().required() })
+  }
+});
 ```
 
 ## Router instance methods

--- a/joi-router.js
+++ b/joi-router.js
@@ -19,6 +19,26 @@ module.exports = Router;
 // expose Joi for use in applications
 Router.Joi = Joi;
 
+// expose validation as standalone middleware
+Router.validate = function createValidateMiddleware(config) {
+  assert(config && typeof config === 'object', 'missing validate config');
+
+  const validate = config.validate || config;
+  const spec = { validate: Object.assign({}, validate) };
+  checkValidators(spec);
+
+  const bodyParser = makeBodyParser(spec);
+  const validator = makeValidator(spec);
+
+  return async function validateMiddleware(ctx, next) {
+    await prepareRequest(ctx, async () => {
+      await bodyParser(ctx, async () => {
+        await validator(ctx, next);
+      });
+    });
+  };
+};
+
 function Router() {
   if (!(this instanceof Router)) {
     return new Router();

--- a/test/index.js
+++ b/test/index.js
@@ -60,6 +60,113 @@ describe('koa-joi-router', () => {
     done();
   });
 
+  describe('.validate()', () => {
+    it('exposes a middleware factory', (done) => {
+      assert.equal('function', typeof router.validate);
+      done();
+    });
+
+    it('validates query data as route middleware', (done) => {
+      const r = router();
+
+      r.get('/a',
+        router.validate({
+          query: Joi.object().keys({
+            q: Joi.number().required()
+          })
+        }),
+        (ctx) => {
+          ctx.body = {
+            q: ctx.request.query.q,
+            type: typeof ctx.request.query.q
+          };
+        });
+
+      const app = makeRouterApp(r);
+
+      test(app).get('/a?q=5')
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.equal(5, res.body.q);
+        assert.equal('number', res.body.type);
+        done();
+      });
+    });
+
+    it('accepts route config objects with validate', (done) => {
+      const r = router();
+
+      r.get('/a',
+        router.validate({
+          validate: {
+            query: Joi.object().keys({
+              q: Joi.number().required()
+            })
+          }
+        }),
+        (ctx) => {
+          ctx.body = ctx.request.query;
+        });
+
+      const app = makeRouterApp(r);
+
+      test(app).get('/a?q=6')
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.equal(6, res.body.q);
+        done();
+      });
+    });
+
+    it('uses configured failure status', (done) => {
+      const r = router();
+
+      r.get('/a',
+        router.validate({
+          failure: 422,
+          query: Joi.object().keys({
+            q: Joi.number().required()
+          })
+        }),
+        (ctx) => {
+          ctx.body = 'validated';
+        });
+
+      const app = makeRouterApp(r);
+
+      test(app).get('/a?q=text')
+      .expect(422, done);
+    });
+
+    it('parses JSON body data as route middleware', (done) => {
+      const r = router();
+
+      r.post('/a',
+        router.validate({
+          type: 'json',
+          body: Joi.object().keys({
+            name: Joi.string().required()
+          })
+        }),
+        (ctx) => {
+          ctx.body = ctx.request.body;
+        });
+
+      const app = makeRouterApp(r);
+
+      test(app).post('/a')
+      .send({ name: 'Ada' })
+      .expect(200)
+      .end((err, res) => {
+        if (err) return done(err);
+        assert.equal('Ada', res.body.name);
+        done();
+      });
+    });
+  });
+
   describe('routes', () => {
     it('is an array', (done) => {
       const r = router();


### PR DESCRIPTION
## Summary
- add router.validate(config) as a standalone Koa middleware factory
- reuse the existing body parser and Joi validation pipeline so behavior stays aligned with route-level validation
- document the middleware API and cover query validation, route-config shape, custom failure status, and JSON body parsing

Closes #56

## Verification
- ./node_modules/.bin/mocha --exit --grep .validate() (5 passing)
- npm run lint
- git diff --check

Note: local npm test on Node.js v24.16.0 still has the existing invalid-JSON parser message assertion mismatch unrelated to this change; the new middleware tests pass.

## Summary by Sourcery

Expose Joi-based request validation as a standalone Koa middleware factory on the router and document its usage.

New Features:
- Add router.validate(config) to create standalone Koa middleware that reuses the existing request validation pipeline for queries and bodies.

Enhancements:
- Leverage existing body parsing and validation logic so middleware-based validation behaves consistently with route-level validation.

Documentation:
- Document the router.validate(config) middleware API with examples of query validation and route-config-shaped input.

Tests:
- Add tests covering router.validate() exposure, query validation, route-config-shaped input, custom failure status codes, and JSON body parsing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `router.validate(config)` as a standalone validation middleware factory for independent request validation.
  * Supports validation of query parameters and JSON request bodies with customizable error status codes.
  * Can be composed directly with route middleware.

* **Documentation**
  * Updated README with examples and usage patterns for standalone validation middleware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->